### PR TITLE
debugg/next.jsの開発サーバーが立ち上がらないバグの修正

### DIFF
--- a/spe-con/.gitignore
+++ b/spe-con/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+certificates

--- a/spe-con/Dockerfile.dev
+++ b/spe-con/Dockerfile.dev
@@ -2,4 +2,5 @@ FROM node:23-alpine
 WORKDIR /app
 COPY package*.json ./
 RUN npm install
+EXPOSE 8080
 CMD ["npm", "run", "dev"]

--- a/spe-con/next.config.ts
+++ b/spe-con/next.config.ts
@@ -1,7 +1,8 @@
-import type { NextConfig } from "next";
+/**
+ * @type {import('next').NextConfig}
+ */
+ const nextConfig = {
+  /* ここにオプション設定を書きます */
+}
 
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;
+export default nextConfig

--- a/spe-con/package.json
+++ b/spe-con/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev --turbopack -p 8080 --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION

 ## 目的
- next.jsのローカルサーバーを立ち上げた際の「このページにはアクセスできません」というエラーをデバック
 ## やったこと
 - package.jsonでhttpsで開発環境にアクセスできるように修正しました
 - next.config.tsファイルの初期設定が古いバージョンの書き方だったので最新バージョンの書き方に修正
- Dockerfile.devで8080番ポートで開発環境が使われるように変更
## 注意事項
- 特にありません

